### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -12,10 +12,10 @@ import { challenges } from '../data/datacache'
 export function trackOrder () {
   return (req: Request, res: Response) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
+    const id = String(req.params.id).replace(/[^\w-]+/g, '').slice(0, 60) // Strict sanitization applied
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => { // Direct field comparison query
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shop-cdql/security/code-scanning/5](https://github.com/Champmsecurity/juice-shop-cdql/security/code-scanning/5)

To fix the issue, the `$where` query should be replaced with a safer alternative that does not involve executing JavaScript code. MongoDB provides other query mechanisms, such as using direct field comparisons (`find` with query objects), which are safer and do not allow code execution. Specifically, the `id` parameter should be used in a query object instead of being interpolated into a JavaScript expression.

Steps to implement the fix:
1. Replace the `$where` query with a direct field comparison query using `{ orderId: id }`.
2. Ensure that `id` is properly sanitized to prevent injection of special characters or unexpected values.
3. Remove the conditional sanitization logic and apply strict sanitization to `req.params.id` regardless of the challenge state.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
